### PR TITLE
No comparison operator for native complex types, skip these

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -19,7 +19,7 @@ skip                = ^PDL::NDBin::Utils_PP$
 [Prereqs / ConfigureRequires]
 PDL::Core::Dev      = 0     ; RT #91304
 [Prereqs / TestRequires]
-PDL                 = 2.004 ; at least 2.4.0 for PDL::Types::types
+PDL                 = 2.030 ; at least 2.030 for PDL::Type->real
 Module::Pluggable   = 3.1   ; earlier versions don't seem to work well in our tests
 Test::PDL           = 0.10  ; test_indx() support
 [Git::NextVersion]

--- a/pp/Actions/actions.pd
+++ b/pp/Actions/actions.pd
@@ -37,14 +37,7 @@ use version;
 my $pdl_version = version->parse( $PDL::Version::VERSION );
 my $propagate_badflag = $pdl_version >= '2.008' ? 'propagate_badflag' : 'propogate_badflag';
 
-our @_REAL_TYPES =
-	map { $_->{ppsym} }
-	# Older PDLs:
-	# - no native complex types, did not have real key
-	# Newer PDLs:
-	# - native complex types, have real key
-	grep { ! exists $_->{real} || $_->{real} }
-	@PDL::Types::typehash{PDL::Types::typesrtkeys()};
+our @_REAL_TYPES = map $_->ppsym, grep $_->real, PDL::Types::types();
 
 # _flatten_into
 #

--- a/pp/Actions/actions.pd
+++ b/pp/Actions/actions.pd
@@ -36,6 +36,15 @@ use version;
 my $pdl_version = version->parse( $PDL::Version::VERSION );
 my $propagate_badflag = $pdl_version >= '2.008' ? 'propagate_badflag' : 'propogate_badflag';
 
+our @_REAL_TYPES =
+	map { $_->{ppsym} }
+	# Older PDLs:
+	# - no native complex types, did not have real key
+	# Newer PDLs:
+	# - native complex types, have real key
+	grep { ! exists $_->{real} || $_->{real} }
+	@PDL::Types::typehash{PDL::Types::typesrtkeys()};
+
 # _flatten_into
 #
 pp_def( '_flatten_into',
@@ -77,6 +86,7 @@ pp_def( '_flatten_into',
 #
 pp_def( '_flatten_into_grid',
 	Pars => "in(); $indx_type b(); double edge(n); $indx_type [o] idx()",
+	GenericTypes => \@_REAL_TYPES,
 	HandleBad => 1,
 	Doc => 'Bin a series of values on a specified grid and flatten into an existing list of indices.',
 	# don't repeat code; PDL_BAD_CODE is available in PDL > 2.007 to
@@ -185,6 +195,7 @@ PDL, otherwise it returns a piddle of type I<long>.',
 pp_def( '_imax_loop',
 	Pars => "in(n); $indx_type idx(n); [o] out(m)",
 	OtherPars => "$PDL_Indx_type msize => m",
+	GenericTypes => \@_REAL_TYPES,
 	HandleBad => 1,
 	Doc => 'Find the maximum in each bin.',
 	Code => '
@@ -211,6 +222,7 @@ pp_def( '_imax_loop',
 pp_def( '_imin_loop',
 	Pars => "in(n); $indx_type idx(n); [o] out(m)",
 	OtherPars => "$PDL_Indx_type msize => m",
+	GenericTypes => \@_REAL_TYPES,
 	HandleBad => 1,
 	Doc => 'Find the minimum in each bin.',
 	Code => '

--- a/pp/Actions/actions.pd
+++ b/pp/Actions/actions.pd
@@ -24,7 +24,8 @@ EOD
 
 # note that version numbers with trailing zeroes (e.g, 0.010) created problems
 # in some of the tests
-pp_setversion( '0.020' );
+our $VERSION = '0.020';
+pp_setversion( $VERSION );
 
 # check for indx/PDL_Indx support
 use PDL::Lite; # load PDL to check definedness of &PDL::indx

--- a/pp/Utils/utils.pd
+++ b/pp/Utils/utils.pd
@@ -31,14 +31,7 @@ use PDL::Lite; # load PDL to check definedness of &PDL::indx
 my $indx_type = defined( &PDL::indx ) ? 'indx' : 'int';
 my $PDL_Indx_type = defined( &PDL::indx ) ? 'PDL_Indx' : 'int';
 
-our @_REAL_TYPES =
-	map { $_->{ppsym} }
-	# Older PDLs:
-	# - no native complex types, did not have real key
-	# Newer PDLs:
-	# - native complex types, have real key
-	grep { ! exists $_->{real} || $_->{real} }
-	@PDL::Types::typehash{PDL::Types::typesrtkeys()};
+our @_REAL_TYPES = map $_->ppsym, grep $_->real, PDL::Types::types();
 
 # ensure that a grid is monotonically increasing or decreasing
 

--- a/pp/Utils/utils.pd
+++ b/pp/Utils/utils.pd
@@ -30,12 +30,22 @@ use PDL::Lite; # load PDL to check definedness of &PDL::indx
 my $indx_type = defined( &PDL::indx ) ? 'indx' : 'int';
 my $PDL_Indx_type = defined( &PDL::indx ) ? 'PDL_Indx' : 'int';
 
+our @_REAL_TYPES =
+	map { $_->{ppsym} }
+	# Older PDLs:
+	# - no native complex types, did not have real key
+	# Newer PDLs:
+	# - native complex types, have real key
+	grep { ! exists $_->{real} || $_->{real} }
+	@PDL::Types::typehash{PDL::Types::typesrtkeys()};
+
 # ensure that a grid is monotonically increasing or decreasing
 
 my %MAP = ( PDL_Indx_type => $PDL_Indx_type );
 
 pp_def( '_validate_grid',
 	Pars => "grid(n)",
+	GenericTypes => \@_REAL_TYPES,
 	Doc => 'Validate a grid.
 
 This function throws an exception if a grid is not monotonically increasing or decreasing.',

--- a/pp/Utils/utils.pd
+++ b/pp/Utils/utils.pd
@@ -23,7 +23,8 @@ EOD
 
 # note that version numbers with trailing zeroes (e.g, 0.010) created problems
 # in some of the tests
-pp_setversion( '0.020' );
+our $VERSION = '0.020';
+pp_setversion( $VERSION );
 
 # check for indx/PDL_Indx support
 use PDL::Lite; # load PDL to check definedness of &PDL::indx

--- a/xs/Makefile.PL
+++ b/xs/Makefile.PL
@@ -4,5 +4,5 @@ use ExtUtils::MakeMaker;
 
 WriteMakefile(
 	NAME    => 'PDL::NDBin::Iterator',
-	VERSION => '0.020',
+	VERSION_FROM => '../lib/PDL/NDBin.pm',
 );


### PR DESCRIPTION
Some small fixes for the addition of native complex types to PDL.

The current code starts to fail at `PDL@2.028` when the native complex types were introduced:

```shell
$ git co master; for PDL_v in 2.026 2.028 2.030 2.034; do cpm install -g --verbose PDL@$PDL_v >/dev/null 2>&1; V=0.020 dzil test >/dev/null 2>&1 && echo "+ OK PDL@$PDL_v" || echo "- Fail PDL@$PDL_v"; done
Already on 'master'
Your branch is up to date with 'origin/master'.
```
```diff
+ OK PDL@2.026
- Fail PDL@2.028
- Fail PDL@2.030
- Fail PDL@2.034
```

With the patch, it only fails on `PDL@2.028` because it uses a new type attribute introduced in `PDL@2.030`:

```shell
$ git co native-complex-types-no-cmp ; for PDL_v in 2.026 2.028 2.030 2.034; do cpm install -g --verbose PDL@$PDL_v >/dev/null 2>&1; V=0.020 dzil test >/dev/null 2>&1 && echo "+ OK PDL@$PDL_v" || echo "- Fail PDL@$PDL_v"; done
Switched to branch 'native-complex-types-no-cmp'
Your branch is up to date with 'origin/native-complex-types-no-cmp'.
```
```diff
+ OK PDL@2.026
- Fail PDL@2.028
+ OK PDL@2.030
+ OK PDL@2.034
```

---

I also have a patch for Test-PDL, but this is just a hack for now as I need to look closer at the code to see if it makes sense to compare native complex types <https://github.com/ebaudrez/Test-PDL/compare/master...zmughal:skip-complex-types-hack-donotmerge>.