### PR TITLE
Update to PDL v2.037

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -19,7 +19,7 @@ skip                = ^PDL::NDBin::Utils_PP$
 [Prereqs / ConfigureRequires]
 PDL::Core::Dev      = 0     ; RT #91304
 [Prereqs / TestRequires]
-PDL                 = 2.004 ; at least 2.4.0 for PDL::Types::types
+PDL                 = 2.035 ; PDL::Version removed in 2.035
 Module::Pluggable   = 3.1   ; earlier versions don't seem to work well in our tests
 Test::PDL           = 0.10  ; test_indx() support
 [Git::NextVersion]

--- a/dist.ini
+++ b/dist.ini
@@ -19,7 +19,7 @@ skip                = ^PDL::NDBin::Utils_PP$
 [Prereqs / ConfigureRequires]
 PDL::Core::Dev      = 0     ; RT #91304
 [Prereqs / TestRequires]
-PDL                 = 2.035 ; PDL::Version removed in 2.035
+PDL                 = 2.037 ; In PDL v2.037, GenericTypes in pp_def defaults to only real types
 Module::Pluggable   = 3.1   ; earlier versions don't seem to work well in our tests
 Test::PDL           = 0.10  ; test_indx() support
 [Git::NextVersion]

--- a/pp/Actions/Makefile.PL
+++ b/pp/Actions/Makefile.PL
@@ -6,7 +6,6 @@ use ExtUtils::MakeMaker;
 my $package = [ "actions.pd", 'Actions_PP', 'PDL::NDBin::Actions_PP' ];
 my %args = (
 	pdlpp_stdargs( $package ),
-	VERSION => '0.020',
 );
 WriteMakefile( %args );
 sub MY::postamble { pdlpp_postamble( $package ) }

--- a/pp/Actions/actions.pd
+++ b/pp/Actions/actions.pd
@@ -27,23 +27,18 @@ EOD
 our $VERSION = '0.020';
 pp_setversion( $VERSION );
 
-# check for indx/PDL_Indx support
-use PDL::Lite; # load PDL to check definedness of &PDL::indx
-my $indx_type = defined( &PDL::indx ) ? 'indx' : 'int';
-my $PDL_Indx_type = defined( &PDL::indx ) ? 'PDL_Indx' : 'int';
-
 # _flatten_into
 #
 pp_def( '_flatten_into',
-	Pars => "in(m); $indx_type b(m); $indx_type [o] idx(m)",
-	OtherPars => "double step; double min; $PDL_Indx_type n",
+	Pars => "in(m); indx b(m); indx [o] idx(m)",
+	OtherPars => "double step; double min; PDL_Indx n",
 	HandleBad => 1,
 	Doc => 'Bin a series of values and flatten into an existing list of indices.',
 	Code => '
 		register double min = $COMP( min );
 		register double step = $COMP( step );
-		register '.$PDL_Indx_type.' j;
-		register '.$PDL_Indx_type.' maxj = $COMP( n ) - 1;
+		register PDL_Indx j;
+		register PDL_Indx maxj = $COMP( n ) - 1;
 		loop(m) %{
 			j = (( $in() - min )/step);
 			if( j < 0 ) j = 0;
@@ -54,8 +49,8 @@ pp_def( '_flatten_into',
 	BadCode => '
 		register double min = $COMP( min );
 		register double step = $COMP( step );
-		register '.$PDL_Indx_type.' j;
-		register '.$PDL_Indx_type.' maxj = $COMP( n ) - 1;
+		register PDL_Indx j;
+		register PDL_Indx maxj = $COMP( n ) - 1;
 		loop(m) %{
 			if( ($ISBAD(in())) || ($ISBAD(b())) ) {
 				$SETBAD( idx() );
@@ -72,7 +67,7 @@ pp_def( '_flatten_into',
 # _flatten_into_grid
 #
 pp_def( '_flatten_into_grid',
-	Pars => "in(); $indx_type b(); double edge(n); $indx_type [o] idx()",
+	Pars => "in(); indx b(); double edge(n); indx [o] idx()",
 	HandleBad => 1,
 	Doc => 'Bin a series of values on a specified grid and flatten into an existing list of indices.',
 	# don't repeat code; PDL_BAD_CODE is available in PDL > 2.007 to
@@ -87,17 +82,17 @@ pp_def( '_flatten_into_grid',
 			     )
 		)
 	} '
-	    '.$PDL_Indx_type.' n = $SIZE(n);
-	    '.$PDL_Indx_type.' n1 = n-1;
-	    '.$PDL_Indx_type.' mid;
+	    PDL_Indx n = $SIZE(n);
+	    PDL_Indx n1 = n-1;
+	    PDL_Indx mid;
 
 	    /* determine sort order of edges */
 	    int up = ($edge(n => n1) >= $edge(n => 0));
 
 	    threadloop %{
 
-	    '.$PDL_Indx_type.' low = 0;
-	    '.$PDL_Indx_type.' high = n1;
+	    PDL_Indx low = 0;
+	    PDL_Indx high = n1;
 
 	    $GENERIC() value = $in();
 
@@ -135,7 +130,7 @@ pp_def( '_flatten_into_grid',
 # modelled after setvaltobad()
 #
 pp_def( '_setnulltobad',
-	Pars => "in(); $indx_type count(); [o] out()",
+	Pars => "in(); indx count(); [o] out()",
 	HandleBad => 1,
 	Inplace => [ 'in' ],
 	Doc => 'Set empty bins to the bad value.',
@@ -154,8 +149,8 @@ pp_def( '_setnulltobad',
 # _icount_loop
 #
 pp_def( '_icount_loop',
-	Pars => "in(n); $indx_type idx(n); $indx_type [o] out(m)",
-	OtherPars => "$PDL_Indx_type msize => m",
+	Pars => "in(n); indx idx(n); indx [o] out(m)",
+	OtherPars => "PDL_Indx msize => m",
 	HandleBad => 1,
 	Doc => 'Count the number of elements in each bin.
 
@@ -163,14 +158,14 @@ This function returns a piddle of type I<indx> if you have a 64-bit-capable
 PDL, otherwise it returns a piddle of type I<long>.',
 	Code => '
 		loop(n) %{
-			register '.$PDL_Indx_type.' j = $idx();
+			register PDL_Indx j = $idx();
 			++( $out(m => j) );
 		%}
 	',
 	BadCode => '
 		loop(n) %{
 			if( ($ISBAD(idx())) || ($ISBAD(in())) ) continue;
-			register '.$PDL_Indx_type.' j = $idx();
+			register PDL_Indx j = $idx();
 			++( $out(m => j) );
 		%}
 	',
@@ -179,13 +174,13 @@ PDL, otherwise it returns a piddle of type I<long>.',
 # _imax_loop
 #
 pp_def( '_imax_loop',
-	Pars => "in(n); $indx_type idx(n); [o] out(m)",
-	OtherPars => "$PDL_Indx_type msize => m",
+	Pars => "in(n); indx idx(n); [o] out(m)",
+	OtherPars => "PDL_Indx msize => m",
 	HandleBad => 1,
 	Doc => 'Find the maximum in each bin.',
 	Code => '
 		loop(n) %{
-			register '.$PDL_Indx_type.' j = $idx();
+			register PDL_Indx j = $idx();
 			if( ($ISBAD(out(m => j))) || ($in() > $out(m => j)) ) {
 				$out(m => j) = $in();
 			}
@@ -194,7 +189,7 @@ pp_def( '_imax_loop',
 	BadCode => '
 		loop(n) %{
 			if( ($ISBAD(idx())) || ($ISBAD(in())) ) continue;
-			register '.$PDL_Indx_type.' j = $idx();
+			register PDL_Indx j = $idx();
 			if( ($ISBAD(out(m => j))) || ($in() > $out(m => j)) ) {
 				$out(m => j) = $in();
 			}
@@ -205,13 +200,13 @@ pp_def( '_imax_loop',
 # _imin_loop
 #
 pp_def( '_imin_loop',
-	Pars => "in(n); $indx_type idx(n); [o] out(m)",
-	OtherPars => "$PDL_Indx_type msize => m",
+	Pars => "in(n); indx idx(n); [o] out(m)",
+	OtherPars => "PDL_Indx msize => m",
 	HandleBad => 1,
 	Doc => 'Find the minimum in each bin.',
 	Code => '
 		loop(n) %{
-			register '.$PDL_Indx_type.' j = $idx();
+			register PDL_Indx j = $idx();
 			if( ($ISBAD(out(m => j))) || ($in() < $out(m => j)) ) {
 				$out(m => j) = $in();
 			}
@@ -220,7 +215,7 @@ pp_def( '_imin_loop',
 	BadCode => '
 		loop(n) %{
 			if( ($ISBAD(idx())) || ($ISBAD(in())) ) continue;
-			register '.$PDL_Indx_type.' j = $idx();
+			register PDL_Indx j = $idx();
 			if( ($ISBAD(out(m => j))) || ($in() < $out(m => j)) ) {
 				$out(m => j) = $in();
 			}
@@ -231,8 +226,8 @@ pp_def( '_imin_loop',
 # _isum_loop
 #
 pp_def( '_isum_loop',
-	Pars => "in(n); $indx_type idx(n); int+ [o] out(m); $indx_type [t] count(m)",
-	OtherPars => "$PDL_Indx_type msize => m",
+	Pars => "in(n); indx idx(n); int+ [o] out(m); indx [t] count(m)",
+	OtherPars => "PDL_Indx msize => m",
 	HandleBad => 1,
 	Doc => 'Sum the elements in each bin.
 
@@ -240,7 +235,7 @@ This function returns a piddle of type I<int> or higher, to reduce the risk of
 overflow when collecting sums.',
 	Code => '
 		loop(n) %{
-			register '.$PDL_Indx_type.' j = $idx();
+			register PDL_Indx j = $idx();
 			$out(m => j) += $in();
 			++( $count(m => j) );
 		%}
@@ -248,7 +243,7 @@ overflow when collecting sums.',
 	BadCode => '
 		loop(n) %{
 			if( ($ISBAD(idx())) || ($ISBAD(in())) ) continue;
-			register '.$PDL_Indx_type.' j = $idx();
+			register PDL_Indx j = $idx();
 			$out(m => j) += $in();
 			++( $count(m => j) );
 		%}
@@ -258,8 +253,8 @@ overflow when collecting sums.',
 # _iavg_loop
 #
 pp_def( '_iavg_loop',
-	Pars => "in(n); $indx_type idx(n); double [o] out(m); $indx_type [t] count(m)",
-	OtherPars => "$PDL_Indx_type msize => m",
+	Pars => "in(n); indx idx(n); double [o] out(m); indx [t] count(m)",
+	OtherPars => "PDL_Indx msize => m",
 	HandleBad => 1,
 	Doc => q[Compute the average of the elements in each bin.
 
@@ -300,14 +295,14 @@ being the default type in PDL and the 'natural' floating-point type in C, it
 also makes the implementation easier.],
 	Code => '
 		loop(n) %{
-			register '.$PDL_Indx_type.' j = $idx();
+			register PDL_Indx j = $idx();
 			$out(m => j) += ( $in() - $out(m => j) ) / ++( $count(m => j) );
 		%}
 	',
 	BadCode => '
 		loop(n) %{
 			if( ($ISBAD(idx())) || ($ISBAD(in())) ) continue;
-			register '.$PDL_Indx_type.' j = $idx();
+			register PDL_Indx j = $idx();
 			$out(m => j) += ( $in() - $out(m => j) ) / ++( $count(m => j) );
 		%}
 	',
@@ -316,8 +311,8 @@ also makes the implementation easier.],
 # _istddev_loop
 #
 pp_def ( '_istddev_loop',
-	Pars => "in(n); $indx_type idx(n); double [o] out(m); $indx_type [t] count(m); double [t] avg(m)",
-	OtherPars => "$PDL_Indx_type msize => m",
+	Pars => "in(n); indx idx(n); double [o] out(m); indx [t] count(m); double [t] avg(m)",
+	OtherPars => "PDL_Indx msize => m",
 	HandleBad => 1,
 	Doc => q[Compute the standard deviation of the elements in each bin.
 
@@ -359,7 +354,7 @@ I<double>. Besides being the default type in PDL and the 'natural'
 floating-point type in C, it also makes the implementation easier.],
 	Code => '
 		loop(n) %{
-			register '.$PDL_Indx_type.' j = $idx();
+			register PDL_Indx j = $idx();
 			double delta = $in() - $avg(m => j);
 			$avg(m => j) += delta / ++( $count(m => j) );
 			$out(m => j) += delta * ( $in() - $avg(m => j) );
@@ -368,7 +363,7 @@ floating-point type in C, it also makes the implementation easier.],
 	BadCode => '
 		loop(n) %{
 			if( ($ISBAD(idx())) || ($ISBAD(in())) ) continue;
-			register '.$PDL_Indx_type.' j = $idx();
+			register PDL_Indx j = $idx();
 			double delta = $in() - $avg(m => j);
 			$avg(m => j) += delta / ++( $count(m => j) );
 			$out(m => j) += delta * ( $in() - $avg(m => j) );
@@ -379,7 +374,7 @@ floating-point type in C, it also makes the implementation easier.],
 # _istddev_post
 #
 pp_def( '_istddev_post',
-	Pars => "in(); $indx_type count(); [o] out()",
+	Pars => "in(); indx count(); [o] out()",
 	HandleBad => 1,
 	Inplace => [ 'in' ],
 	Doc => 'Finalization for _istddev_loop().',

--- a/pp/Actions/actions.pd
+++ b/pp/Actions/actions.pd
@@ -34,7 +34,7 @@ my $PDL_Indx_type = defined( &PDL::indx ) ? 'PDL_Indx' : 'int';
 
 # the name of this method changed some time between PDL 2.007 and 2.008
 use version;
-my $pdl_version = version->parse( $PDL::Version::VERSION );
+my $pdl_version = version->parse( $PDL::VERSION );
 my $propagate_badflag = $pdl_version >= '2.008' ? 'propagate_badflag' : 'propogate_badflag';
 
 # _flatten_into

--- a/pp/Actions/actions.pd
+++ b/pp/Actions/actions.pd
@@ -32,11 +32,6 @@ use PDL::Lite; # load PDL to check definedness of &PDL::indx
 my $indx_type = defined( &PDL::indx ) ? 'indx' : 'int';
 my $PDL_Indx_type = defined( &PDL::indx ) ? 'PDL_Indx' : 'int';
 
-# the name of this method changed some time between PDL 2.007 and 2.008
-use version;
-my $pdl_version = version->parse( $PDL::VERSION );
-my $propagate_badflag = $pdl_version >= '2.008' ? 'propagate_badflag' : 'propogate_badflag';
-
 # _flatten_into
 #
 pp_def( '_flatten_into',
@@ -146,7 +141,7 @@ pp_def( '_setnulltobad',
 	Doc => 'Set empty bins to the bad value.',
 	CopyBadStatusCode => '
 		if( in == out && $ISPDLSTATEGOOD(in) ) {
-			PDL->'.$propagate_badflag.'( out, 1 );
+			PDL->propagate_badflag( out, 1 );
 		}
 		$SETPDLSTATEBAD(out);
 	',
@@ -390,7 +385,7 @@ pp_def( '_istddev_post',
 	Doc => 'Finalization for _istddev_loop().',
 	CopyBadStatusCode => '
 		if( in == out && $ISPDLSTATEGOOD(in) ) {
-			PDL->'.$propagate_badflag.'( out, 1 );
+			PDL->propagate_badflag( out, 1 );
 		}
 		$SETPDLSTATEBAD(out);
 	',

--- a/pp/Actions/actions.pd
+++ b/pp/Actions/actions.pd
@@ -24,7 +24,8 @@ EOD
 
 # note that version numbers with trailing zeroes (e.g, 0.010) created problems
 # in some of the tests
-pp_setversion( '0.020' );
+our $VERSION = '0.020';
+pp_setversion( $VERSION );
 
 # check for indx/PDL_Indx support
 use PDL::Lite; # load PDL to check definedness of &PDL::indx

--- a/pp/Utils/Makefile.PL
+++ b/pp/Utils/Makefile.PL
@@ -6,7 +6,6 @@ use ExtUtils::MakeMaker;
 my $package = [ "utils.pd", 'Utils_PP', 'PDL::NDBin::Utils_PP' ];
 my %args = (
 	pdlpp_stdargs( $package ),
-	VERSION => '0.020',
 );
 WriteMakefile( %args );
 sub MY::postamble { pdlpp_postamble( $package ) }

--- a/pp/Utils/utils.pd
+++ b/pp/Utils/utils.pd
@@ -23,7 +23,8 @@ EOD
 
 # note that version numbers with trailing zeroes (e.g, 0.010) created problems
 # in some of the tests
-pp_setversion( '0.020' );
+our $VERSION = '0.020';
+pp_setversion( $VERSION );
 
 # check for indx/PDL_Indx support
 use PDL::Lite; # load PDL to check definedness of &PDL::indx

--- a/pp/Utils/utils.pd
+++ b/pp/Utils/utils.pd
@@ -26,34 +26,27 @@ EOD
 our $VERSION = '0.020';
 pp_setversion( $VERSION );
 
-# check for indx/PDL_Indx support
-use PDL::Lite; # load PDL to check definedness of &PDL::indx
-my $indx_type = defined( &PDL::indx ) ? 'indx' : 'int';
-my $PDL_Indx_type = defined( &PDL::indx ) ? 'PDL_Indx' : 'int';
-
 # ensure that a grid is monotonically increasing or decreasing
-
-my %MAP = ( PDL_Indx_type => $PDL_Indx_type );
 
 pp_def( '_validate_grid',
 	Pars => "grid(n)",
 	Doc => 'Validate a grid.
 
 This function throws an exception if a grid is not monotonically increasing or decreasing.',
-	Code => ( map { my $p = $_; $p =~ s/%([^%]+)%/$MAP{$1}/eg; $p } '
-	        %PDL_Indx_type% n = $SIZE(n);
-	        %PDL_Indx_type% nm1 = n - 1;
-		%PDL_Indx_type% idx;
+	Code => '
+	        PDL_Indx n = $SIZE(n);
+	        PDL_Indx nm1 = n - 1;
+		PDL_Indx idx;
 	        if ( $grid(n => 0 ) < $grid(n => nm1) ) {
 		  for ( idx = 0 ; idx < n - 1; idx++ ) {
-		      %PDL_Indx_type% idx1 = idx + 1;
+		      PDL_Indx idx1 = idx + 1;
 		      if ( $grid(n => idx ) >= $grid( n => idx1 ) )
 		        barf( "grid is not monotonically increasing\n" );
 		  }
 		}
 	        else if ( $grid(n => 0 ) > $grid(n => nm1) ) {
 		  for ( idx = 0 ; idx < n - 1; idx++ ) {
-		      %PDL_Indx_type% idx1 = idx + 1;
+		      PDL_Indx idx1 = idx + 1;
 		      if ( $grid(n => idx ) <= $grid( n => idx1 ) )
 		        barf( "grid is not monotonically decreasing\n" );
 		  }
@@ -61,7 +54,7 @@ This function throws an exception if a grid is not monotonically increasing or d
 		else {
 	          barf( "grid is not monotonically increasing or decreasing\n" );
 		}
-	' ),
+	',
 );
 
 pp_done();

--- a/t/02-actions.t
+++ b/t/02-actions.t
@@ -35,8 +35,8 @@ sub iter
 	PDL::NDBin::Iterator->new( bins => [ $N ], array => [ $var ], idx => $idx );
 }
 
-# systematically list all types used by PDL
-my @all_types = PDL::Types::types;
+# systematically list all real types used by PDL
+my @all_types = grep $_->real, PDL::Types::types();
 plan tests => 117 + (8 + __PACKAGE__->actions) * @all_types;
 
 # variable declarations

--- a/xs/Makefile.PL
+++ b/xs/Makefile.PL
@@ -4,5 +4,5 @@ use ExtUtils::MakeMaker;
 
 WriteMakefile(
 	NAME    => 'PDL::NDBin::Iterator',
-	VERSION => '0.020',
+	VERSION_FROM => '../lib/PDL/NDBin.pm',
 );


### PR DESCRIPTION
- Use `$VERSION` variable so that `VERSION_FROM` works
- Use `VERSION_FROM` for `PDL::NDBin::Iterator`
- `PDL::Version` was removed in `PDL` v2.035
- Drop `propagate_badflag` back-compat
- Remove back-compat for `PDL_Indx`
- Use `PDL::Type->real` for selecting real types
- Back-compat for only-real `GenericTypes` in `pp_def`

CC: @mohawk2
